### PR TITLE
refactor: 도메인 아키텍처 구조 수정

### DIFF
--- a/src/main/java/com/linkle/domain/entity/Board.java
+++ b/src/main/java/com/linkle/domain/entity/Board.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "BOARD")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/linkle/domain/entity/ChatMessage.java
+++ b/src/main/java/com/linkle/domain/entity/ChatMessage.java
@@ -7,7 +7,6 @@ import jakarta.persistence.*;
 import java.time.Instant;
 
 @Entity
-@Table(name = "CHAT_MESSAGE")
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor @Builder
 public class ChatMessage {

--- a/src/main/java/com/linkle/domain/entity/ChatPart.java
+++ b/src/main/java/com/linkle/domain/entity/ChatPart.java
@@ -7,7 +7,6 @@ import jakarta.persistence.*;
 import java.time.Instant;
 
 @Entity
-@Table(name = "CHAT_PART")
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor @Builder
 public class ChatPart {

--- a/src/main/java/com/linkle/domain/entity/ChatRoom.java
+++ b/src/main/java/com/linkle/domain/entity/ChatRoom.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
-@Table(name = "CHATTING_ROOM")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/linkle/domain/entity/DmPair.java
+++ b/src/main/java/com/linkle/domain/entity/DmPair.java
@@ -6,7 +6,6 @@ import jakarta.persistence.*;
 
 @Entity
 @Table(
-    name = "DM_PAIR",
     uniqueConstraints = {
         @UniqueConstraint(name = "uq_dm_normalized_pair", columnNames = {"smaller_id", "greater_id"})
     }

--- a/src/main/java/com/linkle/domain/entity/Friend.java
+++ b/src/main/java/com/linkle/domain/entity/Friend.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "FRIEND", uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id1", "user_id2"})})
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id1", "user_id2"})})
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/linkle/domain/entity/Linker.java
+++ b/src/main/java/com/linkle/domain/entity/Linker.java
@@ -21,7 +21,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "LINKER")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/linkle/domain/entity/Marker.java
+++ b/src/main/java/com/linkle/domain/entity/Marker.java
@@ -8,7 +8,6 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "marker")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/linkle/domain/entity/Participate.java
+++ b/src/main/java/com/linkle/domain/entity/Participate.java
@@ -7,7 +7,6 @@ import java.time.LocalDate;
 
 @Entity
 @Table(
-    name = "PARTICIPATE",
     uniqueConstraints = {
         @UniqueConstraint(columnNames = {"user_id", "linker_id"})
     }

--- a/src/main/java/com/linkle/domain/entity/Post.java
+++ b/src/main/java/com/linkle/domain/entity/Post.java
@@ -9,7 +9,6 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "POST")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/linkle/domain/entity/Reply.java
+++ b/src/main/java/com/linkle/domain/entity/Reply.java
@@ -6,7 +6,6 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "REPLY")
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/com/linkle/domain/entity/User.java
+++ b/src/main/java/com/linkle/domain/entity/User.java
@@ -18,7 +18,6 @@ import lombok.Setter;
 
 @Entity
 @Table(
-    name = "USER",
     uniqueConstraints = {
         @UniqueConstraint(columnNames = {"email"}),
         @UniqueConstraint(columnNames = {"nickname"})

--- a/src/main/java/com/linkle/repository/FriendRepository.java
+++ b/src/main/java/com/linkle/repository/FriendRepository.java
@@ -20,39 +20,36 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     // findById
 
     // 친구 리스트 (userId만 반환 → 그대로 둠)
-    @Query(value = """
-            SELECT IF(f.user_id1 = :userId, f.user_id2, f.user_id1) AS friend_id
-            FROM FRIEND f
-            WHERE (f.user_id1 = :userId OR f.user_id2 = :userId)
-              AND f.state = 'ACCEPTED'
-        """, nativeQuery = true)
+    @Query("""
+        SELECT CASE WHEN f.user1.userId = :userId THEN f.user2.userId ELSE f.user1.userId END
+        FROM Friend f
+        WHERE (f.user1.userId = :userId OR f.user2.userId = :userId)
+          AND f.state = 'ACCEPTED'
+    """)
     List<Long> findAllFriendIds(@Param("userId") Long userId);
 
     // 받은 요청 조회 (내가 user2일 때)
-    @Query(value = """
-            SELECT *
-            FROM FRIEND f
-            WHERE f.user_id2 = :userId
-              AND f.state = 'REQUESTED'
-        """, nativeQuery = true)
+    @Query("""
+        SELECT f FROM Friend f
+        WHERE f.user2.userId = :userId
+          AND f.state = 'REQUESTED'
+    """)
     List<Friend> findReceivedFriendRequests(@Param("userId") Long userId);
 
     // 보낸 요청 조회 (내가 user1일 때)
-    @Query(value = """
-        SELECT *
-        FROM FRIEND f
-        WHERE f.user_id1 = :userId
+    @Query("""
+        SELECT f FROM Friend f
+        WHERE f.user1.userId = :userId
           AND f.state = 'REQUESTED'
-    """, nativeQuery = true)
+    """)
     List<Friend> findSentFriendRequests(@Param("userId") Long userId);
 
     // 요청 수락(update)
-    @Query(value = """
-            SELECT *
-            FROM FRIEND f
-            WHERE f.friend_id = :friendId
-              AND f.state = 'REQUESTED'
-        """, nativeQuery = true)
+    @Query("""
+        SELECT f FROM Friend f
+        WHERE f.friendId = :friendId
+          AND f.state = 'REQUESTED'
+    """)
     Optional<Friend> findReceivedFriend(@Param("friendId") Long friendId);
 
     // 요청 거절(delete)

--- a/src/main/java/com/linkle/repository/ParticipateRepository.java
+++ b/src/main/java/com/linkle/repository/ParticipateRepository.java
@@ -41,20 +41,19 @@ public interface ParticipateRepository extends JpaRepository<Participate, Long> 
     List<ProfileLinkerCountDTO> countUserParticipationByCategory(@Param("userId") Long userId);
 
     // 링커 검색
-    @Query(value = """
-        SELECT
-            l.linker_id,
-            l.name,
-            l.category_id,
-            l.memo,
-            COUNT(DISTINCT c.room_id) AS chatRoomCount,
-            COUNT(DISTINCT p.post_id) AS postCount
-        FROM linker l
-        LEFT JOIN post p ON p.linker_id = l.linker_id
-        LEFT JOIN chatting_room c ON c.linker_id = l.linker_id
-        WHERE l.name LIKE :word
-        GROUP BY l.linker_id, l.name, l.category_id, l.memo
-        """, nativeQuery = true)
+    @Query("""
+        SELECT l.linkerId,
+               l.name,
+               l.categoryId,
+               l.memo,
+               COUNT(DISTINCT c.roomId),
+               COUNT(DISTINCT p.postId)
+        FROM Linker l
+        LEFT JOIN l.posts p
+        LEFT JOIN ChatRoom c ON c.linker = l
+        WHERE l.name LIKE %:word%
+        GROUP BY l.linkerId, l.name, l.categoryId, l.memo
+    """)
     List<Object[]> findAllWithCountsRaw(@Param("word") String word);
 
     // 🔹 링크별 유저 참여 여부 체크

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,18 @@ spring.jackson.serialization.write-dates-as-timestamps=false
 # false 설정 시 Service 계층에서 트랜잭션 내 데이터 모두 처리 후 세션 닫음
 spring.jpa.open-in-view=false
 
+# Multipart upload 설정 (단일 파일 및 요청 전체 크기 제한)
+# 기본 제한(1MB/10MB)보다 더 큰 이미지 업로드(예: 프로필/포스트 사진)를 지원하기 위해 확장
+spring.servlet.multipart.max-file-size=50MB
+spring.servlet.multipart.max-request-size=50MB
+
 # JWT 토큰 만료 시간 (ms : 1시간, 14일)
 jwt.access-token-expiration=3600000
 jwt.refresh-token-expiration=1209600000
+
+# WebSocket
+ws.endpoint=/ws-stomp
+ws.app-prefixes[0]=/app
+ws.broker-prefixes[0]=/sub
+ws.broker-prefixes[1]=/queue
+ws.with-sockjs=false


### PR DESCRIPTION
Changed

- 엔티티(Entity)에서 @Table(name = "대문자") 어노테이션 전부 제거
    - Linux 기반 운영 서버에서 대소문자를 구별하며 Hibernate가 DB테이블을 소문자로 생성함 → @Table 모두 제거함으로 해결
- ChattingRoom → ChatRoom으로 변경
    - 기존 테이블명과 충돌할 수 있으므로 **Chat 관련 테이블은 모두 삭제**하고 LinkleApplication 실행해주세요.
- native query로 작성된 부분을 JPQL로 변경
    - 테이블명 매핑을 정확하게 하기 위해 JPQL 또는 JPA 함수로 통일하였습니다.