### PR TITLE
fix: User Balance 초기값 null -> 0

### DIFF
--- a/src/main/java/com/linkle/domain/entity/User.java
+++ b/src/main/java/com/linkle/domain/entity/User.java
@@ -77,5 +77,8 @@ public class User {
     @PrePersist
     protected void onCreate() {
         this.createdDate = LocalDate.now();
+        if (this.balance == null) {  // balance가 null이면 0으로 설정
+            this.balance = 0L;
+        }
     }
 }


### PR DESCRIPTION
fix
- 유저 잔액 초기값 null일때 계좌 페이지 오류 -> 0으로 초기화